### PR TITLE
Fixed the overflow of row buttons on the home page 

### DIFF
--- a/assets/css/nrnb.css
+++ b/assets/css/nrnb.css
@@ -78,7 +78,7 @@ h3, h4, h5 {
     padding-top: 10px;
     padding-bottom: 10px;
     margin-top: 10px;
-    width: 350px !important;
+    width: 100% !important;
     background: rgba(255,255,255,0.0) !important;
 }
 


### PR DESCRIPTION
Fixed the overflow of row buttons on the home page when the width becomes less than 410px.
Fixes #27. 