### PR TITLE
Top padding fix on smaller screens for website

### DIFF
--- a/assets/css/nrnb.css
+++ b/assets/css/nrnb.css
@@ -292,7 +292,6 @@ content: "";
     /*color: #FFFFFF;*/
 /*}*/
 
-
 @media (max-width : 979px){
     body {
         padding-top: 0px;

--- a/assets/css/nrnb.css
+++ b/assets/css/nrnb.css
@@ -8,7 +8,6 @@ body {
     background: #000000;
 }
 
-
 footer {
     padding: 20px;
 }
@@ -292,3 +291,10 @@ content: "";
 /*.card:hover h4 {*/
     /*color: #FFFFFF;*/
 /*}*/
+
+
+@media (max-width : 979px){
+    body {
+        padding-top: 0px;
+    }
+}


### PR DESCRIPTION
Fixes issue #36 

Now, for better Navbar alignment, the padding on the top of the website is removed from screens having width less than 979px.