### PR TITLE
Added side padding for white belt on smaller screens

### DIFF
--- a/assets/css/nrnb.css
+++ b/assets/css/nrnb.css
@@ -292,6 +292,14 @@ content: "";
     /*color: #FFFFFF;*/
 /*}*/
 
+@media (max-width : 767px){
+    .white {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
+}
+
 @media (max-width : 979px){
     body {
         padding-top: 0px;


### PR DESCRIPTION
### Problem
The website, when viewed on screen width `< 767px`, had no spacing on the sides for the white belts. This not only looks less structured, but also less readable for some devices (especially with curved edge display).

### Changes made
Added padding of `20px` to both sides for the white portion, which is appropriate for a viewer.

### Screenshots
Before : 
![Screenshot 2024-02-10 162013](https://github.com/nrnb/nrnb.github.io/assets/136724527/fca5bff8-5e67-457c-9c93-2a01816ccc86)

After :
![Screenshot 2024-02-10 161729](https://github.com/nrnb/nrnb.github.io/assets/136724527/3841bd8e-afcc-498a-84ab-93ebce9df203)
