### PR TITLE
Fix broken Google Analytics tracking and favicon path on gsoc.html

### DIFF
--- a/assets/js/page_setup.js
+++ b/assets/js/page_setup.js
@@ -138,7 +138,7 @@ var googleAnalytics =
     '<script>' +
     'window.dataLayer = window.dataLayer || [];' +
     'function gtag(){dataLayer.push(arguments);}' +
-    "gtag('js', new Date());" 
+    "gtag('js', new Date());" +
     "gtag('config', 'G-YSBTBF5042');" +
     '</script>';
 

--- a/gsoc.html
+++ b/gsoc.html
@@ -18,7 +18,7 @@
     <![endif]-->
 
     <!-- Fav and touch icons -->
-    <link rel="shortcut icon" href="../assets/ico/favicon.ico">
+    <link rel="shortcut icon" href="assets/ico/favicon.ico">
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
           href="assets/ico/apple-touch-icon-144-precomposed.png">
     <link rel="apple-touch-icon-precomposed" sizes="114x114"


### PR DESCRIPTION
## Summary

Two small fixes for bugs on the live site.

### 1. Google Analytics is silently broken on every page

**File:** `assets/js/page_setup.js`, line 141

The `googleAnalytics` string is built by concatenating fragments with `+`, but the `+` is missing at the end of line 141:

```js
"gtag('js', new Date());"           // ← no + here
"gtag('config', 'G-YSBTBF5042');" +
'</script>';
```

JavaScript's Automatic Semicolon Insertion terminates the `var googleAnalytics = ...` statement after line 141. The result:

- `googleAnalytics` is assigned a truncated string with no closing `</script>` tag.
- The next line becomes an orphaned expression statement (`"gtag('config', ...);" + '</script>'`) that evaluates and is silently discarded.
- `$('head').append(googleAnalytics)` injects malformed HTML.
- `gtag('config', 'G-YSBTBF5042')` is never called, so GA loads but is never configured. No pageviews are tracked anywhere on the site.

**Fix:** add the missing `+` operator.

### 2. Wrong favicon path on gsoc.html

**File:** `gsoc.html`, line 21

```html
<link rel="shortcut icon" href="../assets/ico/favicon.ico">
```

`gsoc.html` lives at the repo root, so `../assets/` resolves one directory above the root and breaks the path. Every other page on the site uses `assets/ico/favicon.ico`. Changed to match.

## Test plan

- [ ] Load any page on a deployment of this branch; confirm a network request to `googletagmanager.com/gtag/js?id=G-YSBTBF5042` returns 200 **and** that `gtag('config', ...)` runs (check via `window.dataLayer` in devtools or the Network tab).
- [ ] Load `gsoc.html`; confirm the favicon appears in the browser tab.
- [ ] Verify no console errors introduced.

## Notes

Context: I am a GSoC 2026 candidate exploring NRNB repos. I posted these as issues on `nrnb/GoogleSummerOfCode` (#29, #294) before realizing that repo is for project ideas; per maintainer guidance there, opening the PR here directly. Aware that NRNB.org may be replaced in the future — keeping the change minimal and reviewer-friendly.

