### PR TITLE
Fix broken Google Analytics tracking on every page

### DIFF
--- a/assets/js/page_setup.js
+++ b/assets/js/page_setup.js
@@ -138,7 +138,7 @@ var googleAnalytics =
     '<script>' +
     'window.dataLayer = window.dataLayer || [];' +
     'function gtag(){dataLayer.push(arguments);}' +
-    "gtag('js', new Date());" 
+    "gtag('js', new Date());" +
     "gtag('config', 'G-YSBTBF5042');" +
     '</script>';
 


### PR DESCRIPTION
## Summary

`assets/js/page_setup.js` is missing a `+` concatenation operator at the end of line 141. JavaScript's Automatic Semicolon Insertion terminates the `var googleAnalytics = ...` statement at that line, which has two effects:

1. `googleAnalytics` is assigned a truncated string with no closing `</script>` tag — so `$('head').append(googleAnalytics)` on line 145 injects malformed HTML into every page.
2. The next line becomes an orphaned expression statement (`"gtag('config', 'G-YSBTBF5042');" + '</script>'`) that evaluates and is silently discarded. `gtag('config', ...)` is therefore never called, so GA4 loads but is never configured. No pageviews are tracked.

Combined with the fact that the legacy Universal Analytics tag (`UA-19386719-1`, still inline in most pages) was sunset by Google in July 2023, the site has effectively had no working analytics since the GA4 tag was added.

## Reproduction

Ran the exact snippet from `page_setup.js` lines 135–143 in Node.js, before and after the fix:

```
--- BUGGY (current master) ---
Ends with </script>?       false
Contains gtag('config')?   false

--- FIXED ---
Ends with </script>?       true
Contains gtag('config')?   true
```

The bug is reproducible with any JS engine — it's a pure ASI consequence of the missing operator, not browser-specific.

## Change

```diff
-    "gtag('js', new Date());"
+    "gtag('js', new Date());" +
     "gtag('config', 'G-YSBTBF5042');" +
     '</script>';
```

One character, one line.

## Test plan

- [ ] Deploy this branch. Open any page in a browser with devtools.
- [ ] Network tab: confirm `googletagmanager.com/gtag/js?id=G-YSBTBF5042` returns 200 (already happens on master).
- [ ] Console: `window.dataLayer` should contain entries for both `'js'` and `'config'` after page load. On master it only contains `'js'`.
- [ ] In GA4 Realtime, confirm a pageview appears for the deployed URL.

## Notes

- Scope kept to a single line, single file, single bug. A separate observation about the favicon path in `gsoc.html` (`../assets/...`) turned out on reproduction to resolve identically to `assets/...` per RFC 3986 dot-segment removal, so that is not a bug and has been dropped from this PR.
- I am a GSoC 2026 candidate. Originally raised in `nrnb/GoogleSummerOfCode` #29, redirected here by maintainer guidance. Replaces closed PRs #48 and #49.